### PR TITLE
Fixed DecimalDegrees and DMS namespace in @covers annotations

### DIFF
--- a/tests/Location/Formatter/Coordinate/DMSTest.php
+++ b/tests/Location/Formatter/Coordinate/DMSTest.php
@@ -29,7 +29,7 @@ class DMSTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DMS::format
+     * @covers Location\Formatter\Coordinate\DMS::format
      */
     public function testFormatDefaultSeparator()
     {
@@ -39,7 +39,7 @@ class DMSTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DMS::format
+     * @covers Location\Formatter\Coordinate\DMS::format
      */
     public function testFormatCustomSeparator()
     {
@@ -51,7 +51,7 @@ class DMSTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DMS::format
+     * @covers Location\Formatter\Coordinate\DMS::format
      */
     public function testFormatCardinalLetters()
     {
@@ -63,7 +63,7 @@ class DMSTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DMS::format
+     * @covers Location\Formatter\Coordinate\DMS::format
      */
     public function testFormatBothNegative()
     {
@@ -75,7 +75,7 @@ class DMSTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DMS::format
+     * @covers Location\Formatter\Coordinate\DMS::format
      */
     public function testFormatASCIIUnits()
     {

--- a/tests/Location/Formatter/Coordinate/DecimalDegreesTest.php
+++ b/tests/Location/Formatter/Coordinate/DecimalDegreesTest.php
@@ -29,7 +29,7 @@ class DecimalDegreesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DecimalDegrees::format
+     * @covers Location\Formatter\Coordinate\DecimalDegrees::format
      */
     public function testFormatDefaultSeparator()
     {
@@ -41,7 +41,7 @@ class DecimalDegreesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DecimalDegrees::format
+     * @covers Location\Formatter\Coordinate\DecimalDegrees::format
      */
     public function testFormatCustomSeparator()
     {

--- a/tests/Location/Formatter/Coordinate/GeoJSONTest.php
+++ b/tests/Location/Formatter/Coordinate/GeoJSONTest.php
@@ -30,7 +30,7 @@ class GeoJSONTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DecimalDegrees::format
+     * @covers Location\Formatter\Coordinate\DecimalDegrees::format
      */
     public function testFormatDefault()
     {
@@ -42,7 +42,7 @@ class GeoJSONTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DecimalDegrees::format
+     * @covers Location\Formatter\Coordinate\DecimalDegrees::format
      */
     public function testFormatPrecision()
     {

--- a/tests/Location/Formatter/Polygon/GeoJSONTest.php
+++ b/tests/Location/Formatter/Polygon/GeoJSONTest.php
@@ -31,7 +31,7 @@ class GeoJSONTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DecimalDegrees::format
+     * @covers Location\Formatter\Coordinate\DecimalDegrees::format
      */
     public function testFormatDefault()
     {

--- a/tests/Location/Formatter/Polyline/GeoJSONTest.php
+++ b/tests/Location/Formatter/Polyline/GeoJSONTest.php
@@ -31,7 +31,7 @@ class GeoJSONTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Location\Formatter\DecimalDegrees::format
+     * @covers Location\Formatter\Coordinate\DecimalDegrees::format
      */
     public function testFormatDefault()
     {


### PR DESCRIPTION
Fixed DecimalDegrees and DMS namespace in @covers annotation because this mistake was throwing an error like: 
`Trying to @cover or @use not existing method "Location\Formatter\DecimalDegrees::format".
`
 when you tried to run phpunit with coverage flag.