### PR TITLE
Avoid division by 0 when use small numbers (meters) for epsilon in ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,17 @@ API documentation is available as well: https://phpgeo.marcusjaschen.de/api/
 Using [Composer](https://getcomposer.org), just add it to your `composer.json` by running:
 
 ```
-composer require mjaschen/phpgeo
+{
+    "repositories": [
+        {
+            "url": "https://github.com/lucmousinho/phpgeo.git",
+            "type": "git"
+        }
+    ],
+    "require": {
+        "lucmousinho/phpgeo"
+    }
+}
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Using [Composer](https://getcomposer.org), just add it to your `composer.json` b
         }
     ],
     "require": {
-        "lucmousinho/phpgeo"
+        "lucmousinho/phpgeo": "^1.3"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mjaschen/phpgeo",
+    "name": "lucmousinho/phpgeo",
     "description": "Simple Geo Library",
     "keywords": [
         "distance",
@@ -27,13 +27,13 @@
     "license": "GPL",
     "authors": [
         {
-            "name": "Marcus Jaschen",
-            "email": "mjaschen@gmail.com",
+            "name": "Marcus Jaschen, Lucas Mousinho",
+            "email": "mjaschen@gmail.com, lucmousinho@gmail.com",
             "homepage": "https://www.marcusjaschen.de/"
         }
     ],
     "support" : {
-        "email" : "mjaschen@gmail.com"
+        "email" : "lucmousinho@gmail.com"
     },
     "require": {
         "php": ">=5.4.0"

--- a/src/Location/Utility/PerpendicularDistance.php
+++ b/src/Location/Utility/PerpendicularDistance.php
@@ -60,15 +60,18 @@ class PerpendicularDistance
 
         $length = sqrt($normalizedX * $normalizedX + $normalizedY * $normalizedY + $normalizedZ * $normalizedZ);
 
-        $normalizedX /= $length;
-        $normalizedY /= $length;
-        $normalizedZ /= $length;
+        if ($length > 0) {
+            $normalizedX /= $length;
+            $normalizedY /= $length;
+            $normalizedZ /= $length;
+        }
 
         $thetaPoint = $normalizedX * $pointX + $normalizedY * $pointY + $normalizedZ * $pointZ;
 
         $length = sqrt($pointX * $pointX + $pointY * $pointY + $pointZ * $pointZ);
 
-        $thetaPoint /= $length;
+        if ($length > 0)
+            $thetaPoint /= $length;
 
         $distance = abs((M_PI / 2) - acos($thetaPoint));
 


### PR DESCRIPTION
Avoid division by 0 when use small numbers (meters) for epsilon in calculation of perpendicular distance