### PR TITLE
Fix Polygon geoJSON format

### DIFF
--- a/src/Location/Formatter/Polygon/GeoJSON.php
+++ b/src/Location/Formatter/Polygon/GeoJSON.php
@@ -36,7 +36,7 @@ class GeoJSON implements FormatterInterface
         return json_encode(
             [
                 'type'        => 'Polygon',
-                'coordinates' => $points,
+                'coordinates' => [$points],
             ]
         );
     }


### PR DESCRIPTION
> For type "Polygon", the "coordinates" member MUST be an array of linear ring coordinate arrays.


https://tools.ietf.org/html/rfc7946#section-3.1.6