### PR TITLE
SimplifyDouglasPeucker.php fix algorithm

### DIFF
--- a/src/Location/Processor/Polyline/SimplifyDouglasPeucker.php
+++ b/src/Location/Processor/Polyline/SimplifyDouglasPeucker.php
@@ -74,7 +74,7 @@ class SimplifyDouglasPeucker implements SimplifyInterface
 
         $pdCalc = new PerpendicularDistance();
 
-        for ($i = 1; $i <= ($lineSize - 1); $i++) {
+        for ($i = 1; $i <= ($lineSize - 2); $i++) {
             $distance = $pdCalc->getPerpendicularDistance($line[$i], new Line($line[0], $line[$lineSize - 1]));
 
             if ($distance > $distanceMax) {
@@ -84,11 +84,21 @@ class SimplifyDouglasPeucker implements SimplifyInterface
         }
 
         if ($distanceMax > $this->tolerance) {
-            $lineSplitFirst  = array_slice($line, 0, $index);
-            $lineSplitSecond = array_slice($line, $index, $lineSize);
+            $lineSplitFirst  = array_slice($line, 0, $index+1);
+            $lineSplitSecond = array_slice($line, $index, $lineSize-$index);
 
-            $resultsSplit1 = $this->douglasPeucker($lineSplitFirst);
-            $resultsSplit2 = $this->douglasPeucker($lineSplitSecond);
+            if (count($lineSplitFirst) > 2) {
+                $resultsSplit1 = $this->douglasPeucker($lineSplitFirst);
+            }
+            else {
+                $resultsSplit1 = $lineSplitFirst;
+            }
+            if (count($lineSplitSecond) > 2) {
+                $resultsSplit2 = $this->douglasPeucker($lineSplitSecond);
+            }
+            else {
+                $resultsSplit2 = $lineSplitSecond;
+            }
 
             array_pop($resultsSplit1);
 


### PR DESCRIPTION
Fix go throw line points - last point index (line 77)
- There is no need to check last point of line

Fix wrong indexes for splitting lines (lines 87-88)
- Fix losing the last point in lineSplitFirst

Make simplifier ~ twice faster by not calling recursive function when there are 2 or 1 point in splitted line (lines 90-101)