### PR TITLE
rename `isSame()` to `hasSameLocation` in the docs

### DIFF
--- a/docs/300_Comparisons/310_Same_Point_Comparison.md
+++ b/docs/300_Comparisons/310_Same_Point_Comparison.md
@@ -10,14 +10,14 @@ use Location\Coordinate;
 $coordinate1 = new Coordinate(19.820664, -155.468066); // Mauna Kea Summit
 $coordinate2 = new Coordinate(20.709722, -156.253333); // Haleakala Summit
 
-echo $coordinate1->isSame($coordinate2)
+echo $coordinate1->hasSameLocation($coordinate2)
     ? 'Mauna Kea and Haleakala share the same location.'
     : 'Mauna Kea and Haleakala have different locations.';
 
 $coordinate1 = new Coordinate(19.820664, -155.468066); // Mauna Kea Summit
 $coordinate2 = new Coordinate(19.82365, -155.46905); // Gemini North Telescope
 
-echo $coordinate1->isSame($coordinate2, 1000)
+echo $coordinate1->hasSameLocation($coordinate2, 1000)
     ? 'Mauna Kea and the Gemini North Telescope are located within the same 1 km-radius.'
     : 'Mauna Kea and the Gemini North Telescope are located more than 1 km apart.';
 ```


### PR DESCRIPTION
You've already renamed the method in the code in a previous commit:
https://github.com/mjaschen/phpgeo/commit/69cc7374bbd3ab691f00054fd076a388f24bb9fd

So I'm updating the documentation to match your change.