### PR TITLE
Add getMidpoint() to Line Class

### DIFF
--- a/src/Line.php
+++ b/src/Line.php
@@ -124,4 +124,17 @@ class Line implements GeometryInterface
     {
         return new static($this->point2, $this->point1);
     }
+
+    /**
+     * Get the midpoint of a Line segment
+     *
+     * @return Coordinate
+     */
+    public function getMidpoint() : Coordinate
+    {
+        return new Coordinate(
+            (float) ($this->getPoint1()->getLat() + $this->getPoint2()->getLat()) / 2,
+            (float) ($this->getPoint1()->getLng() + $this->getPoint2()->getLng()) / 2,
+        );
+    }
 }

--- a/tests/Location/LineTest.php
+++ b/tests/Location/LineTest.php
@@ -103,4 +103,16 @@ class LineTest extends TestCase
 
         $this->assertEquals($expected, $line->getBounds());
     }
+
+    public function testIfGetMidpointWorksAsExpected()
+    {
+        $point1 = new Coordinate(0, 0);
+        $point2 = new Coordinate(10, 20);
+
+        $line = new Line($point1, $point2);
+
+        $expected = new Coordinate(5, 10);
+
+        $this->assertEquals($expected, $line->getMidpoint());
+    }
 }


### PR DESCRIPTION
The `getMidpiont` method returns a `Coordinate` that's the midpoint of a `Line` object.

I used this in a project to get the distance between a specific `Coordinate` and a `Line` segment,
I might do a separate PR for that if this got accepted.