### PR TITLE
Change assertEquals() to assertEqualsWithDelta()

### DIFF
--- a/tests/Location/LineTest.php
+++ b/tests/Location/LineTest.php
@@ -28,7 +28,7 @@ class LineTest extends TestCase
 
         $line = new Line($point1, $point2);
 
-        $this->assertEquals(2397867.8, $line->getLength(new Vincenty()), '', 0.01);
+        $this->assertEqualsWithDelta(2397867.8, $line->getLength(new Vincenty()), 0.01, '');
     }
 
     public function testGetReverseWorksAsExpected()


### PR DESCRIPTION
Change assertEquals() to assertEqualsWithDelta() inside testCalcauleLength()

PHPUnit was showing the following warning
```
The optional $delta parameter of assertEquals() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertEqualsWithDelta() instead.
```