### PR TITLE
Improve assertion call and fix typos

### DIFF
--- a/tests/Location/CardinalDirection/CardinalDirectionDistancesCalculatorTest.php
+++ b/tests/Location/CardinalDirection/CardinalDirectionDistancesCalculatorTest.php
@@ -19,7 +19,7 @@ class CardinalDirectionDistancesCalculatorTest extends TestCase
     ): void {
         $cardinalDirectionDistancesCalculator = new CardinalDirectionDistancesCalculator();
 
-        self::assertEquals(
+        $this->assertEquals(
             $expected,
             $cardinalDirectionDistancesCalculator->getCardinalDirectionDistances($point1, $point2, new Vincenty())
         );

--- a/tests/Location/CardinalDirection/CardinalDirectionDistancesTest.php
+++ b/tests/Location/CardinalDirection/CardinalDirectionDistancesTest.php
@@ -12,7 +12,7 @@ class CardinalDirectionDistancesTest extends TestCase
     public function testSetNorth(): void
     {
         $north = 2500.0;
-        self::assertSame($north, CardinalDirectionDistances::create()->setNorth($north)->getNorth());
+        $this->assertSame($north, CardinalDirectionDistances::create()->setNorth($north)->getNorth());
     }
 
     public function testSetNorthThrows(): void
@@ -24,7 +24,7 @@ class CardinalDirectionDistancesTest extends TestCase
     public function testSetEast(): void
     {
         $east = 2500.0;
-        self::assertSame($east, CardinalDirectionDistances::create()->setEast($east)->getEast());
+        $this->assertSame($east, CardinalDirectionDistances::create()->setEast($east)->getEast());
     }
 
     public function testSetEastThrows(): void
@@ -36,7 +36,7 @@ class CardinalDirectionDistancesTest extends TestCase
     public function testSetSouth(): void
     {
         $south = 2500.0;
-        self::assertSame($south, CardinalDirectionDistances::create()->setSouth($south)->getSouth());
+        $this->assertSame($south, CardinalDirectionDistances::create()->setSouth($south)->getSouth());
     }
 
     public function testSetSouthThrows(): void
@@ -48,7 +48,7 @@ class CardinalDirectionDistancesTest extends TestCase
     public function testSetWest(): void
     {
         $west = 2500.0;
-        self::assertSame($west, CardinalDirectionDistances::create()->setWest($west)->getWest());
+        $this->assertSame($west, CardinalDirectionDistances::create()->setWest($west)->getWest());
     }
 
     public function testSetWestThrows(): void
@@ -69,9 +69,9 @@ class CardinalDirectionDistancesTest extends TestCase
             ->setSouth($south)
             ->setWest($west);
 
-        self::assertSame($north, $cardinalDirectionDistances->getNorth());
-        self::assertSame($east, $cardinalDirectionDistances->getEast());
-        self::assertSame($south, $cardinalDirectionDistances->getSouth());
-        self::assertSame($west, $cardinalDirectionDistances->getWest());
+        $this->assertSame($north, $cardinalDirectionDistances->getNorth());
+        $this->assertSame($east, $cardinalDirectionDistances->getEast());
+        $this->assertSame($south, $cardinalDirectionDistances->getSouth());
+        $this->assertSame($west, $cardinalDirectionDistances->getWest());
     }
 }

--- a/tests/Location/CardinalDirection/CardinalDirectionTest.php
+++ b/tests/Location/CardinalDirection/CardinalDirectionTest.php
@@ -13,7 +13,7 @@ class CardinalDirectionTest extends TestCase
     /** @dataProvider getCardinalDirectionProvider */
     public function testGetCardinalDirection(Coordinate $point1, Coordinate $point2, string $expected): void
     {
-        self::assertSame(
+        $this->assertSame(
             $expected,
             (new CardinalDirection())->getCardinalDirection($point1, $point2)
         );

--- a/tests/Location/CoordinateTest.php
+++ b/tests/Location/CoordinateTest.php
@@ -113,22 +113,22 @@ class CoordinateTest extends TestCase
         $point1 = new Coordinate(0.0, 0.0);
         $point2 = new Coordinate(0.0, 0.0);
 
-        self::assertTrue($point1->hasSameLocation($point1, 0.0));
-        self::assertTrue($point1->hasSameLocation($point1, 0.1));
+        $this->assertTrue($point1->hasSameLocation($point1, 0.0));
+        $this->assertTrue($point1->hasSameLocation($point1, 0.1));
 
-        self::assertTrue($point1->hasSameLocation($point2, 0.0));
-        self::assertTrue($point1->hasSameLocation($point2, 0.1));
+        $this->assertTrue($point1->hasSameLocation($point2, 0.0));
+        $this->assertTrue($point1->hasSameLocation($point2, 0.1));
 
-        self::assertTrue($point2->hasSameLocation($point1, 0.0));
-        self::assertTrue($point2->hasSameLocation($point1, 0.1));
+        $this->assertTrue($point2->hasSameLocation($point1, 0.0));
+        $this->assertTrue($point2->hasSameLocation($point1, 0.1));
 
         // distance: 1 arc second
         $point2 = new Coordinate(0, 0.0002777778);
 
-        self::assertFalse($point1->hasSameLocation($point2, 0.0));
+        $this->assertFalse($point1->hasSameLocation($point2, 0.0));
 
         // a longitude difference of 1 arc second is about ~30.9 meters on the equator line
-        self::assertFalse($point1->hasSameLocation($point2, 30.85));
-        self::assertTrue($point1->hasSameLocation($point2, 30.95));
+        $this->assertFalse($point1->hasSameLocation($point2, 30.85));
+        $this->assertTrue($point1->hasSameLocation($point2, 30.95));
     }
 }

--- a/tests/Location/Distance/HaversineTest.php
+++ b/tests/Location/Distance/HaversineTest.php
@@ -77,13 +77,13 @@ class HaversineTest extends TestCase
         $this->assertEquals(4952349.639, $distance);
     }
 
-    public function testNotMatchingEllispoids(): void
+    public function testNotMatchingEllipsoids(): void
     {
         $this->expectException(NotMatchingEllipsoidException::class);
 
         $coordinate1 = new Coordinate(19.820664, - 155.468066, $this->ellipsoid);
         $coordinate2 = new Coordinate(20.709722, - 156.253333, new Ellipsoid('AnotherEllipsoid', 6378140.0, 299.2));
 
-        $distance = $this->calculator->getDistance($coordinate1, $coordinate2);
+        $this->calculator->getDistance($coordinate1, $coordinate2);
     }
 }

--- a/tests/Location/PolylineTest.php
+++ b/tests/Location/PolylineTest.php
@@ -134,7 +134,7 @@ class PolylineTest extends TestCase
     {
         $middle = $this->polyline->getAveragePoint();
 
-        self::assertEquals($middle, new Coordinate(47.8, -50.2));
+        $this->assertEquals($middle, new Coordinate(47.8, -50.2));
     }
 
     public function testGetAveragePointCrossingDateLine(): void


### PR DESCRIPTION
# Changed log

- The PHPUnit assertion can be called with `self` or `$this`.
To be consistency, using the `$this` for all assertions because their counts are greater than `self` call.